### PR TITLE
Add HPA resources to kube-save-restore

### DIFF
--- a/internal/backup/kubernetes_client.go
+++ b/internal/backup/kubernetes_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -23,4 +24,7 @@ type KubernetesClient interface {
 
 	// ListSecrets returns a list of all secrets in the specified namespace.
 	ListSecrets(ctx context.Context, namespace string) (*corev1.SecretList, error)
+
+	// ListHorizontalPodAutoscalers returns a list of all horizontal pod autoscalers in the specified namespace.
+	ListHorizontalPodAutoscalers(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error)
 }

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -48,6 +49,12 @@ func (m *MockKubernetesClient) ListSecrets(ctx context.Context, namespace string
 	return args.Get(0).(*corev1.SecretList), args.Error(1)
 }
 
+// ListHorizontalPodAutoscalers mocks the ListHorizontalPodAutoscalers method of the KubernetesClient interface.
+func (m *MockKubernetesClient) ListHorizontalPodAutoscalers(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(*autoscalingv2.HorizontalPodAutoscalerList), args.Error(1)
+}
+
 // setupMockClient creates and configures a MockKubernetesClient with default expectations.
 func setupMockClient() *MockKubernetesClient {
 	mockClient := new(MockKubernetesClient)
@@ -56,6 +63,7 @@ func setupMockClient() *MockKubernetesClient {
 	mockClient.On("ListServices", mock.Anything, "default").Return(&corev1.ServiceList{}, nil)
 	mockClient.On("ListConfigMaps", mock.Anything, "default").Return(&corev1.ConfigMapList{}, nil)
 	mockClient.On("ListSecrets", mock.Anything, "default").Return(&corev1.SecretList{}, nil)
+	mockClient.On("ListHorizontalPodAutoscalers", mock.Anything, "default").Return(&autoscalingv2.HorizontalPodAutoscalerList{}, nil)
 	return mockClient
 }
 

--- a/internal/backup/resource_counter.go
+++ b/internal/backup/resource_counter.go
@@ -37,8 +37,15 @@ func (bm *Manager) countResources(ctx context.Context, namespaces []string) int 
 			continue
 		}
 
+		// Count HPAs
+		hpas, err := bm.client.ListHorizontalPodAutoscalers(ctx, ns)
+		if err != nil {
+			bm.logger.Errorf("Error listing HPAs in namespace %s: %v", ns, err)
+			continue
+		}
+
 		// Sum up the total number of resources
-		total += len(deployments.Items) + len(services.Items) + len(configMaps.Items) + len(secrets.Items)
+		total += len(deployments.Items) + len(services.Items) + len(configMaps.Items) + len(secrets.Items) + len(hpas.Items)
 	}
 	return total
 }

--- a/internal/backup/resources.go
+++ b/internal/backup/resources.go
@@ -19,7 +19,7 @@ func (bm *Manager) backupResource(ctx context.Context, resourceType, namespace s
 	case "secrets":
 		err = bm.backupSecrets(ctx, namespace)
 	case "hpas":
-		err = bm.backupHPAs(ctx, namespace)
+		err = bm.backupHorizontalPodAutoscalers(ctx, namespace)
 	default:
 		return fmt.Errorf("unknown resource type: %s", resourceType)
 	}
@@ -110,8 +110,8 @@ func (bm *Manager) backupSecrets(ctx context.Context, namespace string) error {
 	return nil
 }
 
-// backupHPAs backs up all horizontal pod autoscalers in a given namespace.
-func (bm *Manager) backupHPAs(ctx context.Context, namespace string) error {
+// backupHorizontalPodAutoscalers backs up all horizontal pod autoscalers in a given namespace.
+func (bm *Manager) backupHorizontalPodAutoscalers(ctx context.Context, namespace string) error {
 	hpas, err := bm.client.ListHorizontalPodAutoscalers(ctx, namespace)
 	if err != nil {
 		return fmt.Errorf("error listing HPAs in namespace %s: %v", namespace, err)

--- a/internal/backup/worker.go
+++ b/internal/backup/worker.go
@@ -8,7 +8,7 @@ import (
 
 func (bm *Manager) enqueueTasks(namespaces []string, wp *workerpool.WorkerPool) {
 	for _, ns := range namespaces {
-		for _, resourceType := range []string{"deployments", "services", "configmaps", "secrets"} {
+		for _, resourceType := range []string{"deployments", "services", "configmaps", "secrets", "hpas"} {
 			task := func(ctx context.Context) error {
 				return bm.backupResource(ctx, resourceType, ns)
 			}

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -14,6 +14,7 @@ type ClientInterface interface {
 	NamespaceLister
 	SecretLister
 	ServiceLister
+	HorizontalPodAutoscalerLister
 }
 
 // Client implements the ClientInterface

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -227,7 +227,7 @@ func TestListServices(t *testing.T) {
 	}
 }
 
-func TestListHPAs(t *testing.T) {
+func TestListHorizontalPodAutoscalers(t *testing.T) {
 	client := &Client{Clientset: fake.NewSimpleClientset(&autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "default"},
 	})}

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -223,5 +224,24 @@ func TestListServices(t *testing.T) {
 
 	if services.Items[0].Name != "test-service" {
 		t.Fatalf("expected service name to be 'test-service', got %s", services.Items[0].Name)
+	}
+}
+
+func TestListHPAs(t *testing.T) {
+	client := &Client{Clientset: fake.NewSimpleClientset(&autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-hpa", Namespace: "default"},
+	})}
+
+	hpas, err := client.ListHorizontalPodAutoscalers(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(hpas.Items) != 1 {
+		t.Fatalf("expected 1 hpa, got %d", len(hpas.Items))
+	}
+
+	if hpas.Items[0].Name != "test-hpa" {
+		t.Fatalf("expected hpa name to be 'test-hpa', got %s", hpas.Items[0].Name)
 	}
 }

--- a/internal/kubernetes/hpa.go
+++ b/internal/kubernetes/hpa.go
@@ -7,9 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// HPA defines the methods to list HPAs
-type HPA interface {
-	ListHPAs(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error)
+// HorizontalPodAutoscalerLister defines the methods to list HorizontalPodAutoscalers
+type HorizontalPodAutoscalerLister interface {
+	ListHorizontalPodAutoscalers(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error)
 }
 
 // ListHPAs lists all HPAs in the specified namespace

--- a/internal/kubernetes/hpa.go
+++ b/internal/kubernetes/hpa.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import (
+	"context"
+
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HPA defines the methods to list HPAs
+type HPA interface {
+	ListHPAs(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error)
+}
+
+// ListHPAs lists all HPAs in the specified namespace
+func (c *Client) ListHorizontalPodAutoscalers(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error) {
+	return c.Clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, metav1.ListOptions{})
+}

--- a/internal/restore/resources.go
+++ b/internal/restore/resources.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/chaoscypher/k8s-backup-restore/internal/kubernetes"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,8 @@ func applyResource(client *kubernetes.Client, resource map[string]interface{}, k
 		return applyConfigMap(client, adjustedData, namespace)
 	case "Secret":
 		return applySecret(client, adjustedData, namespace)
+	case "HorizontalPodAutoscaler":
+		return applyHPAS(client, adjustedData, namespace)
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", kind)
 	}
@@ -92,6 +95,21 @@ func applySecret(client *kubernetes.Client, data []byte, namespace string) error
 	_, err := client.Clientset.CoreV1().Secrets(namespace).Update(context.TODO(), &secret, metav1.UpdateOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		_, err = client.Clientset.CoreV1().Secrets(namespace).Create(context.TODO(), &secret, metav1.CreateOptions{})
+	}
+	return err
+}
+
+// applyHPAS applies a HorizontalPodAutoscaler resource to the Kubernetes cluster.
+func applyHPAS(client *kubernetes.Client, data []byte, namespace string) error {
+	var hpa autoscalingv2.HorizontalPodAutoscaler
+	// Unmarshal the JSON data into a HorizontalPodAutoscaler object
+	if err := json.Unmarshal(data, &hpa); err != nil {
+		return fmt.Errorf("error unmarshaling hpa: %v", err)
+	}
+	// Try to update the HorizontalPodAutoscaler, if it does not exist, create it
+	_, err := client.Clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Update(context.TODO(), &hpa, metav1.UpdateOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		_, err = client.Clientset.AutoscalingV2().HorizontalPodAutoscalers(namespace).Create(context.TODO(), &hpa, metav1.CreateOptions{})
 	}
 	return err
 }

--- a/internal/restore/resources.go
+++ b/internal/restore/resources.go
@@ -33,7 +33,7 @@ func applyResource(client *kubernetes.Client, resource map[string]interface{}, k
 	case "Secret":
 		return applySecret(client, adjustedData, namespace)
 	case "HorizontalPodAutoscaler":
-		return applyHPAS(client, adjustedData, namespace)
+		return applyHorizontalPodAutoscalers(client, adjustedData, namespace)
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", kind)
 	}
@@ -99,8 +99,8 @@ func applySecret(client *kubernetes.Client, data []byte, namespace string) error
 	return err
 }
 
-// applyHPAS applies a HorizontalPodAutoscaler resource to the Kubernetes cluster.
-func applyHPAS(client *kubernetes.Client, data []byte, namespace string) error {
+// applyHorizontalPodAutoscalers applies a HorizontalPodAutoscaler resource to the Kubernetes cluster.
+func applyHorizontalPodAutoscalers(client *kubernetes.Client, data []byte, namespace string) error {
 	var hpa autoscalingv2.HorizontalPodAutoscaler
 	// Unmarshal the JSON data into a HorizontalPodAutoscaler object
 	if err := json.Unmarshal(data, &hpa); err != nil {


### PR DESCRIPTION
Resolves https://github.com/ChaosCypher/kube-save-restore/issues/19

- add the ability to backup and restore HPA resources
- Added unit test coverage for new HPA resource
- Added additional integration tests to cover configmaps, secrets, services, and HPA