### PR TITLE
add cronjobs as a supported resource

### DIFF
--- a/internal/backup/kubernetes_client.go
+++ b/internal/backup/kubernetes_client.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -30,4 +31,7 @@ type KubernetesClient interface {
 
 	// ListHorizontalPodAutoscalers returns a list of all horizontal pod autoscalers in the specified namespace.
 	ListHorizontalPodAutoscalers(ctx context.Context, namespace string) (*autoscalingv2.HorizontalPodAutoscalerList, error)
+
+	// ListCronJobs returns a list of all cron jobs in the specified namespace.
+	ListCronJobs(ctx context.Context, namespace string) (*batchv1.CronJobList, error)
 }

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -61,6 +62,12 @@ func (m *MockKubernetesClient) ListHorizontalPodAutoscalers(ctx context.Context,
 	return args.Get(0).(*autoscalingv2.HorizontalPodAutoscalerList), args.Error(1)
 }
 
+// ListCronJobs mocks the ListCronJobs method of the KubernetesClient interface.
+func (m *MockKubernetesClient) ListCronJobs(ctx context.Context, namespace string) (*batchv1.CronJobList, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(*batchv1.CronJobList), args.Error(1)
+}
+
 // setupMockClient creates and configures a MockKubernetesClient with default expectations.
 func setupMockClient() *MockKubernetesClient {
 	mockClient := new(MockKubernetesClient)
@@ -71,6 +78,7 @@ func setupMockClient() *MockKubernetesClient {
 	mockClient.On("ListSecrets", mock.Anything, "default").Return(&corev1.SecretList{}, nil)
 	mockClient.On("ListStatefulSets", mock.Anything, "default").Return(&appsv1.StatefulSetList{}, nil)
 	mockClient.On("ListHorizontalPodAutoscalers", mock.Anything, "default").Return(&autoscalingv2.HorizontalPodAutoscalerList{}, nil)
+	mockClient.On("ListCronJobs", mock.Anything, "default").Return(&batchv1.CronJobList{}, nil)
 	return mockClient
 }
 

--- a/internal/backup/resource_counter.go
+++ b/internal/backup/resource_counter.go
@@ -51,8 +51,15 @@ func (bm *Manager) countResources(ctx context.Context, namespaces []string) int 
 			continue
 		}
 
+		// Count cron jobs
+		cronJobs, err := bm.client.ListCronJobs(ctx, ns)
+		if err != nil {
+			bm.logger.Errorf("Error listing cron jobs in namespace %s: %v", ns, err)
+			continue
+		}
+
 		// Sum up the total number of resources
-		total += len(deployments.Items) + len(services.Items) + len(configMaps.Items) + len(secrets.Items) + len(hpas.Items) + len(statefulSets.Items)
+		total += len(deployments.Items) + len(services.Items) + len(configMaps.Items) + len(secrets.Items) + len(hpas.Items) + len(statefulSets.Items) + len(cronJobs.Items)
 	}
 	return total
 }

--- a/internal/backup/worker.go
+++ b/internal/backup/worker.go
@@ -8,7 +8,7 @@ import (
 
 func (bm *Manager) enqueueTasks(namespaces []string, wp *workerpool.WorkerPool) {
 	for _, ns := range namespaces {
-		for _, resourceType := range []string{"deployments", "services", "configmaps", "secrets", "hpas", "statefulsets"} {
+		for _, resourceType := range []string{"deployments", "services", "configmaps", "secrets", "hpas", "statefulsets", "cronjobs"} {
 			task := func(ctx context.Context) error {
 				return bm.backupResource(ctx, resourceType, ns)
 			}

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -17,6 +17,7 @@ type ClientInterface interface {
 	ServiceLister
 	StatefulSetLister
 	HorizontalPodAutoscalerLister
+	CronJobLister
 }
 
 // Client implements the ClientInterface

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -315,5 +316,24 @@ func TestListHorizontalPodAutoscalers(t *testing.T) {
 
 	if hpas.Items[0].Name != "test-hpa" {
 		t.Fatalf("expected hpa name to be 'test-hpa', got %s", hpas.Items[0].Name)
+	}
+}
+
+func TestListCronJobs(t *testing.T) {
+	client := &Client{Clientset: fake.NewSimpleClientset(&batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cronjob", Namespace: "default"},
+	})}
+
+	cronJobs, err := client.ListCronJobs(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(cronJobs.Items) != 1 {
+		t.Fatalf("expected 1 cronjob, got %d", len(cronJobs.Items))
+	}
+
+	if cronJobs.Items[0].Name != "test-cronjob" {
+		t.Fatalf("expected cronjob name to be 'test-cronjob', got %s", cronJobs.Items[0].Name)
 	}
 }

--- a/internal/kubernetes/cronjob.go
+++ b/internal/kubernetes/cronjob.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CronJobLister is an interface that lists cronjobs.
+type CronJobLister interface {
+	ListCronJobs(ctx context.Context, namespace string) (*batchv1.CronJobList, error)
+}
+
+// ListCronJobs lists all cronjobs in the given namespace.
+func (c *Client) ListCronJobs(ctx context.Context, namespace string) (*batchv1.CronJobList, error) {
+	return c.Clientset.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+}


### PR DESCRIPTION
- adds k8s cronjob resources to the backup/restore process
- adds additional integration/unit tests to cover new feature
- move integration test images from nginx:latest to busybox:latest as it's smaller and speeds up deploying resources