### PR TITLE
Add namespace backup and restore functionality to ksr

### DIFF
--- a/.github/workflows/maintenance-tasks.yaml
+++ b/.github/workflows/maintenance-tasks.yaml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          stale-issue-message: "This issue is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 5 days."
           days-before-stale: 14
           days-before-close: 5

--- a/.github/workflows/maintenance-tasks.yaml
+++ b/.github/workflows/maintenance-tasks.yaml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  actions: write
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/maintenance-tasks.yaml
+++ b/.github/workflows/maintenance-tasks.yaml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          days-before-stale: 14
+          days-before-close: 5

--- a/.github/workflows/maintenance-tasks.yaml
+++ b/.github/workflows/maintenance-tasks.yaml
@@ -1,7 +1,7 @@
-name: 'Close stale issues and PRs'
+name: "Close stale issues and PRs"
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: "30 1 * * *"
 
 permissions:
   actions: write
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
           days-before-stale: 14
           days-before-close: 5

--- a/README.md
+++ b/README.md
@@ -196,17 +196,3 @@ If you find a bug or have a suggestion for improvement:
 1. Check the [existing issues](https://github.com/chaoscypher/kube-save-restore/issues) to avoid duplicates.
 2. If your issue isn't already listed, [open a new issue](https://github.com/chaoscypher/kube-save-restore/issues/new).
 3. Clearly describe the problem or suggestion, including steps to reproduce if applicable.
-
-## License
-
-kube-save-restore is open-source software licensed under the [MIT License](LICENSE).
-
-## Contact
-
-For any inquiries or support, please open an issue on the [GitHub repository](https://github.com/chaoscypher/kube-save-restore).
-
----
-
-<p align="center">
-  Made with ❤️ by <a href="https://github.com/ChaosCypher">ChaosCypher</a>
-</p>

--- a/internal/backup/kubernetes_client.go
+++ b/internal/backup/kubernetes_client.go
@@ -14,6 +14,9 @@ type KubernetesClient interface {
 	// ListNamespaces returns a list of all namespace names in the cluster
 	ListNamespaces(ctx context.Context) ([]string, error)
 
+	// GetNamespaces returns a list of all namespace objects in the cluster
+	GetNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
+
 	// ListDeployments returns a list of all deployments in the specified namespace
 	ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error)
 

--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -59,6 +59,11 @@ func (bm *Manager) PerformBackup(ctx context.Context) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 
+	// First, backup namespaces themselves
+	g.Go(func() error {
+		return bm.backupNamespaces(ctx)
+	})
+
 	// Enqueue backup tasks using errgroup
 	for _, ns := range namespaces {
 		for _, resourceType := range resourceTypes {

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -26,6 +26,12 @@ func (m *MockKubernetesClient) ListNamespaces(ctx context.Context) ([]string, er
 	return args.Get(0).([]string), args.Error(1)
 }
 
+// GetNamespaces mocks the GetNamespaces method of the KubernetesClient interface
+func (m *MockKubernetesClient) GetNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*corev1.NamespaceList), args.Error(1)
+}
+
 // ListDeployments mocks the ListDeployments method of the KubernetesClient interface
 func (m *MockKubernetesClient) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
 	args := m.Called(ctx, namespace)
@@ -78,6 +84,7 @@ func (m *MockKubernetesClient) ListPersistentVolumeClaims(ctx context.Context, n
 func setupMockClient() *MockKubernetesClient {
 	mockClient := new(MockKubernetesClient)
 	mockClient.On("ListNamespaces", mock.Anything).Return([]string{"default", "kube-system"}, nil)
+	mockClient.On("GetNamespaces", mock.Anything).Return(&corev1.NamespaceList{Items: make([]corev1.Namespace, 2)}, nil)
 
 	// Set up expectations for the default namespace
 	mockClient.On("ListDeployments", mock.Anything, "default").Return(&appsv1.DeploymentList{Items: make([]appsv1.Deployment, 1)}, nil)
@@ -164,7 +171,8 @@ func TestCountResources(t *testing.T) {
 	// The total should be the sum of all resources in both namespaces
 	// default namespace: 8 (1 of each resource type)
 	// kube-system namespace: 20 (2+3+4+5+1+2+1+2)
-	expectedCount := 28
+	// namespaces: 2
+	expectedCount := 30
 	assert.Equal(t, expectedCount, count)
 
 	mockClient.AssertExpectations(t)

--- a/internal/backup/resource_counter.go
+++ b/internal/backup/resource_counter.go
@@ -14,7 +14,20 @@ func (bm *Manager) countResources(ctx context.Context) int {
 	}
 
 	var wg sync.WaitGroup
-	resourceCounts := make(chan int, len(namespaces))
+	resourceCounts := make(chan int, len(namespaces)+1) // +1 for namespace count
+
+	// Count namespaces themselves
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		count, err := bm.countNamespaces(ctx)
+		if err != nil {
+			bm.logger.Errorf("Error counting namespaces: %v", err)
+			resourceCounts <- 0
+		} else {
+			resourceCounts <- count
+		}
+	}()
 
 	for _, ns := range namespaces {
 		wg.Add(1)
@@ -144,4 +157,12 @@ func (bm *Manager) countPersistentVolumeClaims(ctx context.Context, namespace st
 		return 0, err
 	}
 	return len(pvcs.Items), nil
+}
+
+func (bm *Manager) countNamespaces(ctx context.Context) (int, error) {
+	namespaces, err := bm.client.GetNamespaces(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return len(namespaces.Items), nil
 }

--- a/internal/backup/resources.go
+++ b/internal/backup/resources.go
@@ -198,3 +198,25 @@ func (bm *Manager) backupPersistantVolumeClaims(ctx context.Context, namespace s
 	}
 	return nil
 }
+
+// backupNamespaces backs up all namespaces in the cluster
+func (bm *Manager) backupNamespaces(ctx context.Context) error {
+	namespaces, err := bm.client.GetNamespaces(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting namespaces: %v", err)
+	}
+
+	for _, namespace := range namespaces.Items {
+		// Namespaces are cluster-scoped, so we store them in a special directory
+		filename := filepath.Join(bm.backupDir, "namespaces", namespace.Name+".json")
+		if bm.dryRun {
+			bm.logger.Infof("Would backup namespace: %s", namespace.Name)
+		} else {
+			if err := bm.saveResource(namespace, "Namespace", filename); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -15,7 +15,7 @@ type NamespaceLister interface {
 
 // ListNamespaces lists all namespaces in the cluster
 func (c *Client) ListNamespaces(ctx context.Context) ([]string, error) {
-	namespaces, err := c.Clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	namespaces, err := c.GetNamespaces(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -3,12 +3,14 @@ package kubernetes
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NamespaceLister defines the method to list Namespaces
 type NamespaceLister interface {
 	ListNamespaces(ctx context.Context) ([]string, error)
+	GetNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
 }
 
 // ListNamespaces lists all namespaces in the cluster
@@ -23,4 +25,9 @@ func (c *Client) ListNamespaces(ctx context.Context) ([]string, error) {
 		namespaceList = append(namespaceList, ns.Name)
 	}
 	return namespaceList, nil
+}
+
+// GetNamespaces retrieves all namespaces in the cluster
+func (c *Client) GetNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	return c.Clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 }

--- a/internal/restore/manager.go
+++ b/internal/restore/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/chaoscypher/kube-save-restore/internal/kubernetes"
 	"github.com/chaoscypher/kube-save-restore/internal/logger"
@@ -38,22 +39,36 @@ func (m *Manager) PerformRestore(restoreDir string, dryRun bool) error {
 		return fmt.Errorf("error getting resource files: %v", err)
 	}
 
+	// Separate namespace files from other resource files
+	namespaceFiles, otherFiles := m.separateNamespaceFiles(files)
+
 	// Count the total number of resources to be restored
-	totalResources := m.countResources(files)
+	totalResources := len(namespaceFiles) + len(otherFiles)
 
 	if dryRun {
 		m.logger.Info("Dry run mode: No resources will be created or modified")
 	}
 
-	// Initialize the worker pool with a maximum concurrency and total resources
-	wp := workerpool.NewWorkerPool(maxConcurrency, totalResources)
-	m.enqueueTasks(files, wp, dryRun)
+	// First, restore namespaces sequentially to ensure they exist before other resources
+	m.logger.Info("Restoring namespaces first...")
+	for _, nsFile := range namespaceFiles {
+		if err := m.RestoreResource(nsFile, dryRun); err != nil {
+			m.logger.Errorf("Error restoring namespace from %s: %v", nsFile, err)
+		}
+	}
 
-	// Run the worker pool and collect any errors
-	errors := wp.Run(context.Background())
-	if len(errors) > 0 {
-		for _, err := range errors {
-			m.logger.Errorf("Error during restore: %v", err)
+	// Then restore other resources using the worker pool
+	if len(otherFiles) > 0 {
+		m.logger.Info("Restoring other resources...")
+		wp := workerpool.NewWorkerPool(maxConcurrency, len(otherFiles))
+		m.enqueueTasks(otherFiles, wp, dryRun)
+
+		// Run the worker pool and collect any errors
+		errors := wp.Run(context.Background())
+		if len(errors) > 0 {
+			for _, err := range errors {
+				m.logger.Errorf("Error during restore: %v", err)
+			}
 		}
 	}
 
@@ -116,4 +131,21 @@ func (m *Manager) RestoreResource(filename string, dryRun bool) error {
 	name, namespace := getResourceIdentifiers(resource)
 	m.logger.Infof("Restoring %s/%s in namespace %s", kind, name, namespace)
 	return applyResource(m.k8sClient, resource, kind, namespace)
+}
+
+// separateNamespaceFiles separates namespace files from other resource files
+func (m *Manager) separateNamespaceFiles(files []string) ([]string, []string) {
+	var namespaceFiles []string
+	var otherFiles []string
+
+	for _, file := range files {
+		// Check if the file is in the namespaces directory
+		if strings.Contains(file, "/namespaces/") {
+			namespaceFiles = append(namespaceFiles, file)
+		} else {
+			otherFiles = append(otherFiles, file)
+		}
+	}
+
+	return namespaceFiles, otherFiles
 }

--- a/internal/restore/manager.go
+++ b/internal/restore/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/chaoscypher/kube-save-restore/internal/kubernetes"
@@ -148,7 +149,8 @@ func (m *Manager) separateNamespaceFiles(files []string) ([]string, []string) {
 
 	for _, file := range files {
 		// Check if the file is in the namespaces directory
-		if strings.Contains(file, "/namespaces/") {
+		dir := filepath.Dir(file)
+		if filepath.Base(dir) == "namespaces" || strings.Contains(filepath.ToSlash(dir), "/namespaces/") {
 			namespaceFiles = append(namespaceFiles, file)
 		} else {
 			otherFiles = append(otherFiles, file)

--- a/internal/restore/resources.go
+++ b/internal/restore/resources.go
@@ -25,6 +25,8 @@ func applyResource(client *kubernetes.Client, resource map[string]interface{}, k
 
 	// Switch based on the kind of resource and call the appropriate function
 	switch kind {
+	case "Namespace":
+		return applyNamespace(client, adjustedData)
 	case "Deployment":
 		return applyDeployment(client, adjustedData, namespace)
 	case "Service":
@@ -44,6 +46,21 @@ func applyResource(client *kubernetes.Client, resource map[string]interface{}, k
 	default:
 		return fmt.Errorf("unsupported resource kind: %s", kind)
 	}
+}
+
+// applyNamespace applies a Namespace resource to the Kubernetes cluster
+func applyNamespace(client *kubernetes.Client, data []byte) error {
+	var namespace corev1.Namespace
+	// Unmarshal the JSON data into a Namespace object
+	if err := json.Unmarshal(data, &namespace); err != nil {
+		return fmt.Errorf("error unmarshaling namespace: %v", err)
+	}
+	// Try to update the Namespace, if it does not exist, create it
+	_, err := client.Clientset.CoreV1().Namespaces().Update(context.TODO(), &namespace, metav1.UpdateOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		_, err = client.Clientset.CoreV1().Namespaces().Create(context.TODO(), &namespace, metav1.CreateOptions{})
+	}
+	return err
 }
 
 // applyDeployment applies a Deployment resource to the Kubernetes cluster


### PR DESCRIPTION
Closes https://github.com/ChaosCypher/kube-save-restore/issues/29

Integration tests show a backup and restore of namespaces first

``` === RUN   TestRunRestore/Actual_Restore
2025/07/31 18:59:21 logger.go:96: INFO: Starting restore operation
2025/07/31 18:59:21 logger.go:96: INFO: Restoring namespaces first...
2025/07/31 18:59:21 logger.go:108: INFO: Restoring Namespace/kube-node-lease in namespace cluster-scoped
2025/07/31 18:59:21 logger.go:108: INFO: Restoring Namespace/kube-public in namespace cluster-scoped
2025/07/31 18:59:21 logger.go:108: INFO: Restoring Namespace/kube-system in namespace cluster-scoped
2025/07/31 18:59:21 logger.go:108: INFO: Restoring Namespace/default in namespace cluster-scoped
2025/07/31 18:59:21 logger.go:96: INFO: Namespace restoration completed
2025/07/31 18:59:21 logger.go:96: INFO: Restoring other resources...
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace default
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-node-lease
2025/07/31 18:59:21 logger.go:108: INFO: Restoring Service/kubernetes in namespace default
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-public
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/cluster-info in namespace kube-public
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/coredns in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-apiserver-legacy-service-account-token-tracking in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/extension-apiserver-authentication in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-proxy in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kubeadm-config in namespace kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Restoring ConfigMap/kubelet-config in namespace kube-system
```

```
=== RUN   TestRunBackup/Dry_Run_Backup
2025/07/31 18:59:21 logger.go:96: INFO: Starting backup operation
2025/07/31 18:59:21 logger.go:96: INFO: Dry run mode: No files will be written
2025/07/31 18:59:21 logger.go:108: INFO: Would backup service: default/kubernetes
2025/07/31 18:59:21 logger.go:108: INFO: Would backup namespace: default
2025/07/31 18:59:21 logger.go:108: INFO: Would backup namespace: kube-node-lease
2025/07/31 18:59:21 logger.go:108: INFO: Would backup namespace: kube-public
2025/07/31 18:59:21 logger.go:108: INFO: Would backup namespace: kube-system
2025/07/31 18:59:21 logger.go:108: INFO: Would backup secret: kube-system/bootstrap-token-j3odga
2025/07/31 18:59:21 logger.go:108: INFO: Would backup service: kube-system/kube-dns
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-node-lease/kube-root-ca.crt
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: default/kube-root-ca.crt
2025/07/31 18:59:21 logger.go:108: INFO: Would backup deployment: kube-system/coredns
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-public/cluster-info
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-public/kube-root-ca.crt
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/coredns
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/extension-apiserver-authentication
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/kube-apiserver-legacy-service-account-token-tracking
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/kube-proxy
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/kube-root-ca.crt
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/kubeadm-config
2025/07/31 18:59:21 logger.go:108: INFO: Would backup configmap: kube-system/kubelet-config
2025/07/31 18:59:21 logger.go:108: INFO: Dry run completed. 19 resources would be backed up to: /tmp/kube-save-restore-test
=== RUN   TestRunBackup/Actual_Backup
2025/07/31 18:59:21 logger.go:96: INFO: Starting backup operation
2025/07/31 18:59:21 logger.go:108: INFO: Backup completed. 19 resources saved to: /tmp/kube-save-restore-test
```