### PR TITLE
add daemonset backup/restore functionality to ksr

### DIFF
--- a/internal/backup/kubernetes_client.go
+++ b/internal/backup/kubernetes_client.go
@@ -27,6 +27,9 @@ type KubernetesClient interface {
 	// ListConfigMaps returns a list of all config maps in the specified namespace
 	ListConfigMaps(ctx context.Context, namespace string) (*corev1.ConfigMapList, error)
 
+	// ListDaemonSets returns a list of all daemon sets in the specified namespace
+	ListDaemonSets(ctx context.Context, namespace string) (*appsv1.DaemonSetList, error)
+
 	// ListSecrets returns a list of all secrets in the specified namespace
 	ListSecrets(ctx context.Context, namespace string) (*corev1.SecretList, error)
 

--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -20,7 +20,7 @@ type Logger interface {
 }
 
 // resourceTypes defines the Kubernetes resource types to be backed up
-var resourceTypes = []string{"deployments", "services", "configmaps", "secrets", "serviceaccounts", "hpas", "statefulsets", "cronjobs", "jobs", "pvcs", "ingresses"}
+var resourceTypes = []string{"deployments", "services", "configmaps", "secrets", "serviceaccounts", "hpas", "statefulsets", "daemonsets", "cronjobs", "jobs", "pvcs", "ingresses"}
 
 // Manager handles the backup process for Kubernetes resources
 type Manager struct {

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -93,6 +93,12 @@ func (m *MockKubernetesClient) ListPersistentVolumeClaims(ctx context.Context, n
 	return args.Get(0).(*corev1.PersistentVolumeClaimList), args.Error(1)
 }
 
+// ListDaemonSets mocks the ListDaemonSets method of the KubernetesClient interface
+func (m *MockKubernetesClient) ListDaemonSets(ctx context.Context, namespace string) (*appsv1.DaemonSetList, error) {
+	args := m.Called(ctx, namespace)
+	return args.Get(0).(*appsv1.DaemonSetList), args.Error(1)
+}
+
 // ListIngresses mocks the ListIngresses method of the KubernetesClient interface
 func (m *MockKubernetesClient) ListIngresses(ctx context.Context, namespace string) (*networkingv1.IngressList, error) {
 	args := m.Called(ctx, namespace)
@@ -113,6 +119,7 @@ func setupMockClient() *MockKubernetesClient {
 	mockClient.On("ListServiceAccounts", mock.Anything, "default").Return(&corev1.ServiceAccountList{Items: make([]corev1.ServiceAccount, 1)}, nil)
 	mockClient.On("ListStatefulSets", mock.Anything, "default").Return(&appsv1.StatefulSetList{Items: make([]appsv1.StatefulSet, 1)}, nil)
 	mockClient.On("ListHorizontalPodAutoscalers", mock.Anything, "default").Return(&autoscalingv2.HorizontalPodAutoscalerList{Items: make([]autoscalingv2.HorizontalPodAutoscaler, 1)}, nil)
+	mockClient.On("ListDaemonSets", mock.Anything, "default").Return(&appsv1.DaemonSetList{Items: make([]appsv1.DaemonSet, 1)}, nil)
 	mockClient.On("ListCronJobs", mock.Anything, "default").Return(&batchv1.CronJobList{Items: make([]batchv1.CronJob, 1)}, nil)
 	mockClient.On("ListJobs", mock.Anything, "default").Return(&batchv1.JobList{Items: make([]batchv1.Job, 1)}, nil)
 	mockClient.On("ListPersistentVolumeClaims", mock.Anything, "default").Return(&corev1.PersistentVolumeClaimList{Items: make([]corev1.PersistentVolumeClaim, 1)}, nil)
@@ -125,6 +132,7 @@ func setupMockClient() *MockKubernetesClient {
 	mockClient.On("ListServiceAccounts", mock.Anything, "kube-system").Return(&corev1.ServiceAccountList{Items: make([]corev1.ServiceAccount, 3)}, nil)
 	mockClient.On("ListStatefulSets", mock.Anything, "kube-system").Return(&appsv1.StatefulSetList{Items: make([]appsv1.StatefulSet, 1)}, nil)
 	mockClient.On("ListHorizontalPodAutoscalers", mock.Anything, "kube-system").Return(&autoscalingv2.HorizontalPodAutoscalerList{Items: make([]autoscalingv2.HorizontalPodAutoscaler, 2)}, nil)
+	mockClient.On("ListDaemonSets", mock.Anything, "kube-system").Return(&appsv1.DaemonSetList{Items: make([]appsv1.DaemonSet, 2)}, nil)
 	mockClient.On("ListCronJobs", mock.Anything, "kube-system").Return(&batchv1.CronJobList{Items: make([]batchv1.CronJob, 1)}, nil)
 	mockClient.On("ListJobs", mock.Anything, "kube-system").Return(&batchv1.JobList{Items: make([]batchv1.Job, 1)}, nil)
 	mockClient.On("ListPersistentVolumeClaims", mock.Anything, "kube-system").Return(&corev1.PersistentVolumeClaimList{Items: make([]corev1.PersistentVolumeClaim, 2)}, nil)
@@ -195,10 +203,10 @@ func TestCountResources(t *testing.T) {
 
 	// The total should be the sum of all resources in both namespaces
 	// and cluster-wide resources
-	// default namespace: 11 (1 of each resource type)
-	// kube-system namespace: 26
+	// default namespace: 12 (1 of each resource type)
+	// kube-system namespace: 28
 	// cluster-wide: 2
-	expectedCount := 39
+	expectedCount := 42
 	assert.Equal(t, expectedCount, count)
 
 	mockClient.AssertExpectations(t)

--- a/internal/backup/resource_counter.go
+++ b/internal/backup/resource_counter.go
@@ -60,6 +60,7 @@ func (bm *Manager) countResourcesInNamespace(ctx context.Context, namespace stri
 		"secrets":         bm.countSecrets,
 		"serviceaccounts": bm.countServiceAccounts,
 		"statefulsets":    bm.countStatefulSets,
+		"daemonsets":      bm.countDaemonSets,
 		"hpas":            bm.countHorizontalPodAutoscalers,
 		"cronjobs":        bm.countCronJobs,
 		"jobs":            bm.countJobs,
@@ -144,6 +145,14 @@ func (bm *Manager) countStatefulSets(ctx context.Context, namespace string) (int
 		return 0, err
 	}
 	return len(statefulSets.Items), nil
+}
+
+func (bm *Manager) countDaemonSets(ctx context.Context, namespace string) (int, error) {
+	daemonSets, err := bm.client.ListDaemonSets(ctx, namespace)
+	if err != nil {
+		return 0, err
+	}
+	return len(daemonSets.Items), nil
 }
 
 func (bm *Manager) countHorizontalPodAutoscalers(ctx context.Context, namespace string) (int, error) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -834,8 +834,8 @@ func TestBackupAndRestoreDaemonSet(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  "busybox",
-							Image: "busybox:latest",
+							Name:    "busybox",
+							Image:   "busybox:latest",
 							Command: []string{"sleep", "3600"},
 						},
 					},

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -11,6 +11,7 @@ import (
 // ClientInterface defines the methods that a Kubernetes client should implement
 type ClientInterface interface {
 	ConfigMapLister
+	DaemonSetLister
 	DeploymentLister
 	NamespaceLister
 	SecretLister

--- a/internal/kubernetes/daemonset.go
+++ b/internal/kubernetes/daemonset.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import (
+	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// DaemonSetLister defines the method to list DaemonSets
+type DaemonSetLister interface {
+	ListDaemonSets(ctx context.Context, namespace string) (*appsv1.DaemonSetList, error)
+}
+
+// ListDaemonSets lists all DaemonSets in the specified namespace
+func (c *Client) ListDaemonSets(ctx context.Context, namespace string) (*appsv1.DaemonSetList, error) {
+	return c.Clientset.AppsV1().DaemonSets(namespace).List(ctx, metav1.ListOptions{})
+}

--- a/internal/restore/resources.go
+++ b/internal/restore/resources.go
@@ -40,6 +40,8 @@ func applyResource(client *kubernetes.Client, resource map[string]interface{}, k
 		return applyServiceAccount(client, adjustedData, namespace)
 	case "StatefulSet":
 		return applyStatefulSet(client, adjustedData, namespace)
+	case "DaemonSet":
+		return applyDaemonSet(client, adjustedData, namespace)
 	case "HorizontalPodAutoscaler":
 		return applyHorizontalPodAutoscalers(client, adjustedData, namespace)
 	case "CronJob":
@@ -156,6 +158,21 @@ func applyStatefulSet(client *kubernetes.Client, data []byte, namespace string) 
 	_, err := client.Clientset.AppsV1().StatefulSets(namespace).Update(context.TODO(), &statefulSet, metav1.UpdateOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		_, err = client.Clientset.AppsV1().StatefulSets(namespace).Create(context.TODO(), &statefulSet, metav1.CreateOptions{})
+	}
+	return err
+}
+
+// applyDaemonSet applies a DaemonSet resource to the Kubernetes cluster
+func applyDaemonSet(client *kubernetes.Client, data []byte, namespace string) error {
+	var daemonSet appsv1.DaemonSet
+	// Unmarshal the JSON data into a DaemonSet object
+	if err := json.Unmarshal(data, &daemonSet); err != nil {
+		return fmt.Errorf("error unmarshaling daemon set: %v", err)
+	}
+	// Try to update the DaemonSet, if it does not exist, create it
+	_, err := client.Clientset.AppsV1().DaemonSets(namespace).Update(context.TODO(), &daemonSet, metav1.UpdateOptions{})
+	if err != nil && errors.IsNotFound(err) {
+		_, err = client.Clientset.AppsV1().DaemonSets(namespace).Create(context.TODO(), &daemonSet, metav1.CreateOptions{})
 	}
 	return err
 }


### PR DESCRIPTION
```
2025-08-12T19:45:34.3163476Z === RUN   TestBackupAndRestoreDaemonSet
2025-08-12T19:45:34.3210395Z 2025/08/12 19:45:34 logger.go:96: INFO: Starting backup operation
2025-08-12T19:45:37.7446622Z 2025/08/12 19:45:37 logger.go:108: INFO: Backup completed. 90 resources saved to: /tmp/kube-save-restore-test
2025-08-12T19:45:37.7867063Z 2025/08/12 19:45:37 logger.go:96: INFO: Starting restore operation
2025-08-12T19:45:37.7880217Z 2025/08/12 19:45:37 logger.go:96: INFO: Restoring namespaces first...
2025-08-12T19:45:37.7881424Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/default in namespace cluster-scoped
2025-08-12T19:45:37.7882520Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/kube-node-lease in namespace cluster-scoped
2025-08-12T19:45:37.7885321Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/kube-public in namespace cluster-scoped
2025-08-12T19:45:37.7886856Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/kube-system in namespace cluster-scoped
2025-08-12T19:45:37.7887995Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-configmap-namespace in namespace cluster-scoped
2025-08-12T19:45:37.7889274Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-daemonset-namespace in namespace cluster-scoped
2025-08-12T19:45:37.7890923Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-hpa-namespace in namespace cluster-scoped
2025-08-12T19:45:37.7893111Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-deployment-namespace in namespace cluster-scoped
2025-08-12T19:45:37.7893831Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-secret-namespace in namespace cluster-scoped
2025-08-12T19:45:37.7894490Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-service-namespace in namespace cluster-scoped
2025-08-12T19:45:37.8057111Z 2025/08/12 19:45:37 logger.go:108: INFO: Restoring Namespace/test-statefulset-namespace in namespace cluster-scoped
2025-08-12T19:45:38.0052214Z 2025/08/12 19:45:38 logger.go:96: INFO: Namespace restoration completed
2025-08-12T19:45:38.0053598Z 2025/08/12 19:45:38 logger.go:96: INFO: Restoring other resources...
2025-08-12T19:45:38.0054715Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/default in namespace default
2025-08-12T19:45:38.0055767Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace default
2025-08-12T19:45:38.0057046Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring Service/kubernetes in namespace default
2025-08-12T19:45:38.0058046Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/default in namespace kube-node-lease
2025-08-12T19:45:38.0062382Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/cluster-info in namespace kube-public
2025-08-12T19:45:38.0063601Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/default in namespace kube-public
2025-08-12T19:45:38.0064599Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-public
2025-08-12T19:45:38.0065638Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-node-lease
2025-08-12T19:45:38.0066604Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/coredns in namespace kube-system
2025-08-12T19:45:38.0067907Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/extension-apiserver-authentication in namespace kube-system
2025-08-12T19:45:38.0244865Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-apiserver-legacy-service-account-token-tracking in namespace kube-system
2025-08-12T19:45:38.0451377Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-proxy in namespace kube-system
2025-08-12T19:45:38.0644675Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace kube-system
2025-08-12T19:45:38.0853869Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kubeadm-config in namespace kube-system
2025-08-12T19:45:38.1046837Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kubelet-config in namespace kube-system
2025-08-12T19:45:38.1254367Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring DaemonSet/kube-proxy in namespace kube-system
2025-08-12T19:45:38.1450727Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring Deployment/coredns in namespace kube-system
2025-08-12T19:45:38.1655515Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring Secret/bootstrap-token-dbh5fe in namespace kube-system
2025-08-12T19:45:38.1849256Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/attachdetach-controller in namespace kube-system
2025-08-12T19:45:38.2055115Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/bootstrap-signer in namespace kube-system
2025-08-12T19:45:38.2248224Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/certificate-controller in namespace kube-system
2025-08-12T19:45:38.2454961Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/clusterrole-aggregation-controller in namespace kube-system
2025-08-12T19:45:38.2649730Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/coredns in namespace kube-system
2025-08-12T19:45:38.2856020Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/cronjob-controller in namespace kube-system
2025-08-12T19:45:38.3050630Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/daemon-set-controller in namespace kube-system
2025-08-12T19:45:38.3259585Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/default in namespace kube-system
2025-08-12T19:45:38.3474902Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/deployment-controller in namespace kube-system
2025-08-12T19:45:38.3647812Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/disruption-controller in namespace kube-system
2025-08-12T19:45:38.3851049Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/endpoint-controller in namespace kube-system
2025-08-12T19:45:38.4045658Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/endpointslice-controller in namespace kube-system
2025-08-12T19:45:38.4248858Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/endpointslicemirroring-controller in namespace kube-system
2025-08-12T19:45:38.4451988Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/ephemeral-volume-controller in namespace kube-system
2025-08-12T19:45:38.4646825Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/expand-controller in namespace kube-system
2025-08-12T19:45:38.4849860Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/generic-garbage-collector in namespace kube-system
2025-08-12T19:45:38.5053148Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/horizontal-pod-autoscaler in namespace kube-system
2025-08-12T19:45:38.5248101Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/job-controller in namespace kube-system
2025-08-12T19:45:38.5452186Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/kube-proxy in namespace kube-system
2025-08-12T19:45:38.5645783Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/legacy-service-account-token-cleaner in namespace kube-system
2025-08-12T19:45:38.5850045Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/namespace-controller in namespace kube-system
2025-08-12T19:45:38.6043432Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/node-controller in namespace kube-system
2025-08-12T19:45:38.6248222Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/persistent-volume-binder in namespace kube-system
2025-08-12T19:45:38.6452848Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/pod-garbage-collector in namespace kube-system
2025-08-12T19:45:38.6647317Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/pv-protection-controller in namespace kube-system
2025-08-12T19:45:38.6852830Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/pvc-protection-controller in namespace kube-system
2025-08-12T19:45:38.7047187Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/replicaset-controller in namespace kube-system
2025-08-12T19:45:38.7254355Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/replication-controller in namespace kube-system
2025-08-12T19:45:38.7453496Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/resourcequota-controller in namespace kube-system
2025-08-12T19:45:38.7651301Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/root-ca-cert-publisher in namespace kube-system
2025-08-12T19:45:38.7845286Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/service-account-controller in namespace kube-system
2025-08-12T19:45:38.8050087Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/service-cidrs-controller in namespace kube-system
2025-08-12T19:45:38.8256142Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/statefulset-controller in namespace kube-system
2025-08-12T19:45:38.8451217Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/storage-provisioner in namespace kube-system
2025-08-12T19:45:38.8646277Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/token-cleaner in namespace kube-system
2025-08-12T19:45:38.8850703Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/ttl-after-finished-controller in namespace kube-system
2025-08-12T19:45:38.9045367Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/ttl-controller in namespace kube-system
2025-08-12T19:45:38.9250762Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ServiceAccount/validatingadmissionpolicy-status-controller in namespace kube-system
2025-08-12T19:45:38.9445491Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring Service/kube-dns in namespace kube-system
2025-08-12T19:45:38.9648063Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-configmap-namespace
2025-08-12T19:45:38.9860495Z 2025/08/12 19:45:38 logger.go:108: INFO: Restoring ConfigMap/test-configmap in namespace test-configmap-namespace
2025-08-12T19:45:39.0084299Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-configmap-namespace
2025-08-12T19:45:39.0279647Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-daemonset-namespace
2025-08-12T19:45:39.0458428Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring DaemonSet/test-daemonset in namespace test-daemonset-namespace
2025-08-12T19:45:39.0651266Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-daemonset-namespace
2025-08-12T19:45:39.0846490Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-deployment-namespace
2025-08-12T19:45:39.1051180Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring Deployment/test-deployment in namespace test-deployment-namespace
2025-08-12T19:45:39.1245727Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-deployment-namespace
2025-08-12T19:45:39.1459394Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-hpa-namespace
2025-08-12T19:45:39.1657673Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring Deployment/test-hpa-deployment in namespace test-hpa-namespace
2025-08-12T19:45:39.1854325Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring HorizontalPodAutoscaler/test-hpa in namespace test-hpa-namespace
2025-08-12T19:45:39.2048945Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-hpa-namespace
2025-08-12T19:45:39.2259345Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-secret-namespace
2025-08-12T19:45:39.2473262Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring Secret/test-secret in namespace test-secret-namespace
2025-08-12T19:45:39.2646839Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-secret-namespace
2025-08-12T19:45:39.2853127Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-service-namespace
2025-08-12T19:45:39.3062345Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-service-namespace
2025-08-12T19:45:39.3247633Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring Service/test-service in namespace test-service-namespace
2025-08-12T19:45:39.3454352Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ConfigMap/kube-root-ca.crt in namespace test-statefulset-namespace
2025-08-12T19:45:39.3656895Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring ServiceAccount/default in namespace test-statefulset-namespace
2025-08-12T19:45:39.3861813Z 2025/08/12 19:45:39 logger.go:108: INFO: Restoring StatefulSet/test-statefulset in namespace test-statefulset-namespace
2025-08-12T19:45:39.5862347Z 2025/08/12 19:45:39 logger.go:108: INFO: Restore completed. 90 resources restored from: /tmp/kube-save-restore-test
2025-08-12T19:45:39.6047705Z --- PASS: TestBackupAndRestoreDaemonSet (5.29s)
```